### PR TITLE
Remove second title

### DIFF
--- a/docs/rules/g101_hardcoded_credentials.md
+++ b/docs/rules/g101_hardcoded_credentials.md
@@ -3,8 +3,6 @@ id: g101
 title: G101: Hardcoded credentials
 ---
 
-# G101: Hardcoded credentials
-
 The use of hard-coded passwords increases the possibility of password guessing tremendously. This plugin test looks for all string literals and checks the following conditions:
 
 Variables are considered to look like a password if they have match any one of:

--- a/docs/rules/g102_bind_all_interfaces.md
+++ b/docs/rules/g102_bind_all_interfaces.md
@@ -3,8 +3,6 @@ id: g102
 title: G102: Bind to all interfaces
 ---
 
-# G102: Bind to all interfaces
-
 Binding to all network interfaces can potentially open up a service to traffic on unintended interfaces, that may not be properly documented or secured. This plugin test looks for a string pattern “0.0.0.0” that may indicate a hardcoded binding to all network interfaces.
 
 ## Example code:

--- a/docs/rules/g103_use_of_unsage_block.md
+++ b/docs/rules/g103_use_of_unsage_block.md
@@ -3,8 +3,6 @@ id: g103
 title: G103: Use of unsafe block
 ---
 
-# G103: Use of unsafe block
-
 Using the unsafe package in Go gives you low-level memory management and many of the strength of the C language but also gives flexibility to the attacker of your application. The pointer arithmetic is one of the examples from the unsafe package which can be used for data leak, memory corruption or even execution of attackers own script.
 
 Also, you should keep in mind that the "unsafe" package is not protected by [Go 1 compatibility guidelines](https://golang.org/doc/go1compat).

--- a/docs/rules/g104_unchecked_erros.md
+++ b/docs/rules/g104_unchecked_erros.md
@@ -3,8 +3,6 @@ id: g104
 title: G104: Audit errors not checked
 ---
 
-# G104: Audit errors not checked
-
 Really useful feature of Golang is the ability to return a tuple of a result and an error value from a function. There is an unspoken rule in Golang that the result of a function is unsafe until you make check the error value. Many security exploits can be performed when the error value is not checked.
 
 ## Example code:


### PR DESCRIPTION
The titles are two on every single rule. I remove that.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>