### PR TITLE
Clickable link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # securego.github.io
-securego.io website
+
+[Gosec documentation - securego.io](securego.io) website
 
 - built with https://docusaurus.io/
 - hosted using netlify


### PR DESCRIPTION
Many times I have to go to the docs I have to copy and paste the link but why?

I think it will be good if we have a clickable link to the Gosec documentation

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>