### PR TITLE
Add one more example to g107

### DIFF
--- a/docs/rules/g107_url_arg_to_http_request_as_taint_input.md
+++ b/docs/rules/g107_url_arg_to_http_request_as_taint_input.md
@@ -33,10 +33,41 @@ func main() {
 }
 ```
 
+```
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+var url string = "https://www.google.com"
+
+func main() {
+
+	resp, err := http.Get(url)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s", body)
+}
+```
+
 ## Gosec command line output
 
 ```
 [examples/main.go:12] - G107: Potential HTTP request made with variable url (Confidence: MEDIUM, Severity: MEDIUM)
+  > http.Get(url)
+```
+
+```
+[/Users/mvrachev/Martins/go/src/github.com/securego/examples/main.go:17] - G107: Potential HTTP request made with variable url (Confidence: MEDIUM, Severity: MEDIUM)
   > http.Get(url)
 ```
 


### PR DESCRIPTION
It will be useful if there is one more example in the docs
for rule G107.
An example which demonstrates a more likely mistake.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>